### PR TITLE
adhere to padded-blocks

### DIFF
--- a/queue.js
+++ b/queue.js
@@ -1,7 +1,6 @@
 'use strict'
 
 function fastqueue (context, worker, limit) {
-
   if (typeof context === 'function') {
     limit = worker
     worker = context


### PR DESCRIPTION
We are in the process of adding back the rule `padded-blocks` into `standard`. It was temporarily disabled because of a bug in eslint which now has been fixed.

This pull request makes sure that your coding style is compliant with the new version.

Please see feross/standard#170 for more info.