### PR TITLE
Feature: implement global error handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ function worker (arg, cb) {
 * <a href="#getQueue"><code>queue#<b>getQueue()</b></code></a>
 * <a href="#kill"><code>queue#<b>kill()</b></code></a>
 * <a href="#killAndDrain"><code>queue#<b>killAndDrain()</b></code></a>
+* <a href="#error"><code>queue#<b>error()</b></code></a>
 * <a href="#concurrency"><code>queue#<b>concurrency</b></code></a>
 * <a href="#drain"><code>queue#<b>drain</b></code></a>
 * <a href="#empty"><code>queue#<b>empty</b></code></a>
@@ -157,6 +158,13 @@ function.
 ### queue.killAndDrain()
 
 Same than `kill` but the `drain` function will be called before reset to empty.
+
+-------------------------------------------------------
+<a name="error"></a>
+### queue.error(handler)
+
+Set a global error handler. `handler(err, task)` will be called
+when any of the tasks return an error.
 
 -------------------------------------------------------
 <a name="concurrency"></a>

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,7 @@ declare function fastq<C, T = any, R = any>(worker: fastq.worker<C, T, R>, concu
 declare namespace fastq {
   type worker<C, T = any, R = any> = (this: C, task: T, cb: fastq.done<R>) => void
   type done<R = any> = (err: Error | null, result?: R) => void
+  type errorHandler<T = any> = (err: Error, task: T) => void
 
   interface queue<T = any, R = any> {
     push(task: T, done: done<R>): void
@@ -15,6 +16,7 @@ declare namespace fastq {
     getQueue(): T[]
     kill(): any
     killAndDrain(): any
+    error(handler: errorHandler): void
     concurrency: number
     drain(): any
     empty: () => void

--- a/test/test.js
+++ b/test/test.js
@@ -536,3 +536,19 @@ test('unshift without cb', function (t) {
     cb()
   }
 })
+
+test('push with worker throwing error', function (t) {
+  t.plan(5)
+  var q = buildQueue(function (task, cb) {
+    cb(new Error('test error'), null)
+  }, 1)
+  q.error(function (err, task) {
+    t.ok(err instanceof Error, 'global error handler should catch the error')
+    t.match(err.message, /test error/, 'error message should be "test error"')
+    t.equal(task, 42, 'The task executed should be passed')
+  })
+  q.push(42, function (err) {
+    t.ok(err instanceof Error, 'global error handler should catch the error')
+    t.match(err.message, /test error/, 'error message should be "test error"')
+  })
+})

--- a/test/test.js
+++ b/test/test.js
@@ -548,7 +548,7 @@ test('push with worker throwing error', function (t) {
     t.equal(task, 42, 'The task executed should be passed')
   })
   q.push(42, function (err) {
-    t.ok(err instanceof Error, 'global error handler should catch the error')
+    t.ok(err instanceof Error, 'push callback should catch the error')
     t.match(err.message, /test error/, 'error message should be "test error"')
   })
 })


### PR DESCRIPTION
Hi, I've implemented the `async.queue` like global error handler, as described in issue #22.
I've updated the readme, typedefs, and I've added an extra test too.

One thing I wasn't sure about was whether I should catch errors that happen inside a worker, or just rely on the worker like every other push callback does for returning the error.
I've chosen to rely on the worker to return error using the callback, but I could do it the other way if that's more similar to how `async.queue` does it.

Please let me know if there's anything that should be done differently, or if I've missed anything (like style guides or conventions used by the project)