### PR TITLE
validate concurrency parameter

### DIFF
--- a/queue.js
+++ b/queue.js
@@ -9,6 +9,10 @@ function fastqueue (context, worker, concurrency) {
     context = null
   }
 
+  if (concurrency < 1) {
+    throw new Error('fastqueue concurrency must be greater than 1')
+  }
+
   var cache = reusify(Task)
   var queueHead = null
   var queueTail = null

--- a/test/test.js
+++ b/test/test.js
@@ -3,6 +3,16 @@
 var test = require('tape')
 var buildQueue = require('../')
 
+test('concurrency', function (t) {
+  t.plan(2)
+  t.throws(buildQueue.bind(null, worker, 0))
+  t.doesNotThrow(buildQueue.bind(null, worker, 1))
+
+  function worker (arg, cb) {
+    cb(null, true)
+  }
+})
+
 test('worker execution', function (t) {
   t.plan(3)
 


### PR DESCRIPTION
try to resolve issue #32.

I'm not sure which is better:

solution 1:   just throw when concurrency less than 1
solution 2:  set default concurrency as fallback

I prefer solution 1 personally.