### PR TITLE
fix(typescript): adjust push and unshift methods to not require callback

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,8 +7,8 @@ declare namespace fastq {
   type errorHandler<T = any> = (err: Error, task: T) => void
 
   interface queue<T = any, R = any> {
-    push(task: T, done: done<R>): void
-    unshift(task: T, done: done<R>): void
+    push(task: T, done?: done<R>): void
+    unshift(task: T, done?: done<R>): void
     pause(): any
     resume(): any
     idle(): boolean

--- a/test/example.ts
+++ b/test/example.ts
@@ -9,6 +9,8 @@ queue.push('world', (err, result) => {
   console.log('the result is', result)
 })
 
+queue.push('push without cb')
+
 queue.concurrency
 
 queue.drain()
@@ -35,6 +37,8 @@ queue.unshift('world', (err, result) => {
   if (err) throw err
   console.log('the result is', result)
 })
+
+queue.unshift('unshift without cb')
 
 function worker(task: any, cb: fastq.done) {
   cb(null, 'hello ' + task)


### PR DESCRIPTION
TS typings don't reflect that `done` param is optional for `.push()` and `.unshift()` methods.

Behaviour is already tested in https://github.com/mcollina/fastq/blob/9b929c0ac40fe6b1ea0d2c4560dddf0d4be4851e/test/test.js#L524-L548

Just TS types force to define it (even if it's no-op)