### PR TITLE
feat: run to completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ import * as fastq from "fastq";
 import type { queue, done } from "fastq";
 
 type Task = {
-  id: number  
+  id: number
 }
 
 const q: queue<Task> = fastq(worker, 1)
@@ -124,7 +124,7 @@ q.push({ id: 42}).catch((err) => console.error(err))
 
 async function asyncWorker (arg: Task): Promise<void> {
   // No need for a try-catch block, fastq handles errors automatically
-  console.log(arg.id)  
+  console.log(arg.id)
 }
 ```
 
@@ -288,6 +288,13 @@ This promise could be ignored as it will not lead to a `'unhandledRejection'`.
 
 Add a task at the beginning of the queue. The returned `Promise`  will be fulfilled (rejected)
 when the task is completed successfully (unsuccessfully).
+
+This promise could be ignored as it will not lead to a `'unhandledRejection'`.
+
+<a name="drained"></a>
+#### queue.drained() => Promise
+
+Wait for the queue to be drained. The returned `Promise` will be resolved when all tasks in the queue have been processed by a worker.
 
 This promise could be ignored as it will not lead to a `'unhandledRejection'`.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -27,6 +27,7 @@ declare namespace fastq {
   interface queueAsPromised<T = any, R = any> extends queue<T, R> {
     push(task: T): Promise<R>
     unshift(task: T): Promise<R>
+    drained(): Promise<void>
   }
 
   function promise<C, T = any, R = any>(context: C, worker: fastq.asyncWorker<C, T, R>, concurrency: number): fastq.queueAsPromised<T, R>

--- a/queue.js
+++ b/queue.js
@@ -223,6 +223,7 @@ function queueAsPromised (context, worker, concurrency) {
 
   queue.push = push
   queue.unshift = unshift
+  queue.drained = drained
 
   return queue
 
@@ -264,13 +265,12 @@ function queueAsPromised (context, worker, concurrency) {
     return p
   }
 
-  function runToCompletion () {
-    var p = new Promise(function (resolve, reject) {
+  function drained () {
+    var previousDrain = queue.drain
+
+    var p = new Promise(function (resolve) {
       queue.drain = function () {
-        // call already assigned drain function
-        if (typeof queue.drain === 'function') {
-          queue.drain()
-        }
+        previousDrain()
         resolve()
       }
     })

--- a/queue.js
+++ b/queue.js
@@ -263,6 +263,20 @@ function queueAsPromised (context, worker, concurrency) {
 
     return p
   }
+
+  function runToCompletion () {
+    var p = new Promise(function (resolve, reject) {
+      queue.drain = function () {
+        // call already assigned drain function
+        if (typeof queue.drain === 'function') {
+          queue.drain()
+        }
+        resolve()
+      }
+    })
+
+    return p
+  }
 }
 
 module.exports = fastqueue

--- a/test/promise.js
+++ b/test/promise.js
@@ -59,6 +59,20 @@ test('multiple executions', async function (t) {
   }
 })
 
+test('runToCompletion', async function (t) {
+  const queue = buildQueue(worker, 1)
+  const toExec = [1, 2, 3, 4, 5]
+  let count = 0
+
+  async function worker (arg) {
+    count++
+    return
+  }
+
+  await queue.runToCompletion()
+  t.equal(count, 5)
+})
+
 test('set this', async function (t) {
   t.plan(1)
   const that = {}

--- a/test/promise.js
+++ b/test/promise.js
@@ -87,6 +87,22 @@ test('drained', async function (t) {
   t.equal(count, toExec.length * 2)
 })
 
+test('drained with exception should not throw', async function (t) {
+  const queue = buildQueue(worker, 2)
+
+  const toExec = new Array(10).fill(10)
+
+  async function worker () {
+    throw new Error('foo')
+  }
+
+  toExec.forEach(function (i) {
+    queue.push(i)
+  })
+
+  await queue.drained()
+})
+
 test('drained with drain function', async function (t) {
   let drainCalled = false
   const queue = buildQueue(worker, 2)

--- a/test/promise.js
+++ b/test/promise.js
@@ -76,6 +76,8 @@ test('drained', async function (t) {
 
   await queue.drained()
 
+  t.equal(count, toExec.length)
+
   toExec.forEach(function (i) {
     queue.push(i)
   })


### PR DESCRIPTION
This essentially adds a simple helper function to wait for the `queueAsPromised` to be drained, quite useful if `fastq` is used as a `Promise.all()` function but with concurrency.

Fixes #47 