### PR TITLE
Update README on error callback expected behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Same than `kill` but the `drain` function will be called before reset to empty.
 ### queue.error(handler)
 
 Set a global error handler. `handler(err, task)` will be called
-when any of the tasks return an error.
+each time a task is completed, `err` will be not null if the task has thrown an error.
 
 -------------------------------------------------------
 <a name="concurrency"></a>


### PR DESCRIPTION
Mentioned in #42 

Updates the documentation in order to specify that the `.error` function will be called each time a task gets completed with `err` not null or null depending on whenever the task threw an error or not.