### PR TITLE
fix: queueAsPromised.drained() resolves while queue is idle

### DIFF
--- a/queue.js
+++ b/queue.js
@@ -266,6 +266,12 @@ function queueAsPromised (context, worker, concurrency) {
   }
 
   function drained () {
+    if (queue.idle()) {
+      return new Promise(function (resolve) {
+        resolve()
+      })
+    }
+
     var previousDrain = queue.drain
 
     var p = new Promise(function (resolve) {

--- a/test/promise.js
+++ b/test/promise.js
@@ -129,6 +129,33 @@ test('drained with drain function', async function (t) {
   t.equal(drainCalled, true)
 })
 
+test('drained while idle should resolve', async function (t) {
+  const queue = buildQueue(worker, 2)
+
+  async function worker (arg) {
+    await sleep(arg)
+  }
+
+  await queue.drained()
+})
+
+test('drained while idle should not call the drain function', async function (t) {
+  let drainCalled = false
+  const queue = buildQueue(worker, 2)
+
+  queue.drain = function () {
+    drainCalled = true
+  }
+
+  async function worker (arg) {
+    await sleep(arg)
+  }
+
+  await queue.drained()
+
+  t.equal(drainCalled, false)
+})
+
 test('set this', async function (t) {
   t.plan(1)
   const that = {}


### PR DESCRIPTION
This PR fixes https://github.com/mcollina/fastq/issues/63 by returning early from `queueAsPromised.drained` when the queue is idle.

NOTE: This implementation does NOT call `queue.drain` if the queue is idle, which IMO makes sense. The docs state that `queue.drain` is a "Function that will be called when the last item from the queue has been processed by a worker." When the queue is idle and the user calls `await queue.drained()`, it's reasonable to assume that the user has already added and processed items from the queue, so `queue.drain` should have already been called when the last item was processed.

@mcollina Most of the code in `queue.js` looks like dark magic to my inexperienced eyes, so please take a close look to confirm that this implementation won't have any unintended effects.