### PR TITLE
Remove tests from npm package to reduce npm package size

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,11 @@
     "type": "git",
     "url": "git+https://github.com/mcollina/fastq.git"
   },
+  "files": [
+    "*.js",
+    "*.mjs",
+    "*.d.ts"
+  ],
   "keywords": [
     "fast",
     "queue",


### PR DESCRIPTION
Removing the tests (and GitHub workflows) from the package by only including the root files reduces the package file by about half (tested with `npm` 9.8.0).
Before:
```
❯ npm pack
...
npm notice === Tarball Details ===
npm notice name:          fastq
npm notice version:       1.15.0
npm notice filename:      fastq-1.15.0.tgz
npm notice package size:  8.6 kB
npm notice unpacked size: 39.4 kB
npm notice shasum:        95987241d4b02262d717bf1d57df7542a4e5ad8d
npm notice integrity:     sha512-JewKD7kBsuCx1[...]1kZVl0dlXgXFQ==
npm notice total files:   14
```
After:
```
❯ npm pack
...
npm notice === Tarball Details ===
npm notice name:          fastq
npm notice version:       1.15.0
npm notice filename:      fastq-1.15.0.tgz
npm notice package size:  5.5 kB
npm notice unpacked size: 19.2 kB
npm notice shasum:        943cf41058968f769c197f547381b0a108836290
npm notice integrity:     sha512-lBOEBRXpJXBdJ[...]YcOvc5TaizdbA==
npm notice total files:   8
```