### PR TITLE
fix: unshift with worker throwing error (#77)

### DIFF
--- a/queue.js
+++ b/queue.js
@@ -118,6 +118,7 @@ function fastqueue (context, worker, concurrency) {
     current.release = release
     current.value = value
     current.callback = done || noop
+    current.errorHandler = errorHandler
 
     if (_running === self.concurrency || self.paused) {
       if (queueHead) {

--- a/test/test.js
+++ b/test/test.js
@@ -564,3 +564,19 @@ test('push with worker throwing error', function (t) {
     t.match(err.message, /test error/, 'error message should be "test error"')
   })
 })
+
+test('unshift with worker throwing error', function (t) {
+  t.plan(5)
+  var q = buildQueue(function (task, cb) {
+    cb(new Error('test error'), null)
+  }, 1)
+  q.error(function (err, task) {
+    t.ok(err instanceof Error, 'global error handler should catch the error')
+    t.match(err.message, /test error/, 'error message should be "test error"')
+    t.equal(task, 42, 'The task executed should be passed')
+  })
+  q.unshift(42, function (err) {
+    t.ok(err instanceof Error, 'unshift callback should catch the error')
+    t.match(err.message, /test error/, 'error message should be "test error"')
+  })
+})


### PR DESCRIPTION
By comparing the `push` and `unshift` functions, the difference is easy to spot. 