### PR TITLE
docs: fix unhandledRejection statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,22 +280,16 @@ Arguments:
 Add a task at the end of the queue. The returned `Promise`  will be fulfilled (rejected)
 when the task is completed successfully (unsuccessfully).
 
-This promise could be ignored as it will not lead to a `'unhandledRejection'`.
-
 <a name="unshiftPromise"></a>
 #### queue.unshift(task) => Promise
 
 Add a task at the beginning of the queue. The returned `Promise`  will be fulfilled (rejected)
 when the task is completed successfully (unsuccessfully).
 
-This promise could be ignored as it will not lead to a `'unhandledRejection'`.
-
 <a name="drained"></a>
 #### queue.drained() => Promise
 
 Wait for the queue to be drained. The returned `Promise` will be resolved when all tasks in the queue have been processed by a worker.
-
-This promise could be ignored as it will not lead to a `'unhandledRejection'`.
 
 ## License
 


### PR DESCRIPTION
The statement seems not correct (node v20.x):

> This promise could be ignored as it will not lead to a `'unhandledRejection'`.


```js
const queue = require('fastq').promise(worker, 1);

async function worker (arg) {
  throw new Error('app error');
}

process.on('unhandledRejection', (err) => {
  console.error({ unhandledRejection: err });
});

async function run () {
  const result = await queue.push(42);
  console.log('the result is', result);
}

run();
```

Output:

```
{
  unhandledRejection: Error: app error....
}
```