### PR TITLE
fix: ensure drained() resolves after async tasks complete

### DIFF
--- a/queue.js
+++ b/queue.js
@@ -289,7 +289,7 @@ function queueAsPromised (context, worker, _concurrency) {
 
   function drained () {
     var p = new Promise(function (resolve) {
-      setImmediate(() => {
+      process.nextTick(function () {
         if (queue.idle()) {
           resolve()
         } else {

--- a/queue.js
+++ b/queue.js
@@ -288,19 +288,19 @@ function queueAsPromised (context, worker, _concurrency) {
   }
 
   function drained () {
-    if (queue.idle()) {
-      return new Promise(function (resolve) {
-        resolve()
-      })
-    }
-
-    var previousDrain = queue.drain
-
     var p = new Promise(function (resolve) {
-      queue.drain = function () {
-        previousDrain()
-        resolve()
-      }
+      setImmediate(() => {
+        if (queue.idle()) {
+          resolve()
+        } else {
+          var previousDrain = queue.drain
+          queue.drain = function () {
+            if (typeof previousDrain === 'function') previousDrain()
+            resolve()
+            queue.drain = previousDrain
+          }
+        }
+      })
     })
 
     return p


### PR DESCRIPTION
fixes #88 