### PR TITLE
Exclude test and benchmark files from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,6 @@
 scripts
+test
+bench.js
 CLAUDE.md
 .github
+eslint.config.js


### PR DESCRIPTION
## Summary

- Adds `test/`, `bench.js`, and `eslint.config.js` to `.npmignore` so they are excluded from the published npm package
- These files serve no purpose for consumers and add ~32KB to every install
- With ~50M weekly downloads, this adds up

## Changes

Updated `.npmignore` to exclude:
- `test/` - test suite
- `bench.js` - benchmark script
- `eslint.config.js` - linting config