### PR TITLE
fix: preserve running count when aborting queued tasks

### DIFF
--- a/queue.js
+++ b/queue.js
@@ -210,6 +210,7 @@ function fastqueue (context, worker, _concurrency) {
       current.value = null
       current.callback = noop
       current.errorHandler = null
+      current.next = null
 
       // Call error handler if present
       if (errorHandler) {
@@ -219,8 +220,9 @@ function fastqueue (context, worker, _concurrency) {
       // Call callback with error
       callback.call(context, new Error('abort'))
 
-      // Release the task back to the pool
-      current.release(current)
+      // This task was queued, so return it to the pool without updating
+      // the running worker count.
+      cache.release(current)
 
       current = next
     }

--- a/test/promise.js
+++ b/test/promise.js
@@ -290,6 +290,37 @@ test('drained should handle undefined drain function', async function (t) {
   t.pass('drained resolved successfully with undefined drain')
 })
 
+test('drained waits for running tasks after abort', async function (t) {
+  let finish
+  let didDrain = false
+
+  const queue = buildQueue(function () {
+    return new Promise(function (resolve) {
+      finish = resolve
+    })
+  }, 1)
+
+  const running = queue.push(1)
+  queue.push(2)
+  queue.abort()
+
+  const drained = queue.drained().then(function () {
+    didDrain = true
+  })
+
+  await immediate()
+
+  t.equal(queue.running(), 1, 'running task is preserved')
+  t.equal(didDrain, false, 'queue does not drain while work is running')
+
+  finish()
+  await running
+  await drained
+
+  t.equal(didDrain, true, 'queue drains after running work completes')
+  t.equal(queue.running(), 0, 'running returns to zero')
+})
+
 test('abort rejects all pending promises', async function (t) {
   const queue = buildQueue(worker, 1)
   const promises = []

--- a/test/test.js
+++ b/test/test.js
@@ -696,6 +696,81 @@ test('abort', function (t) {
   }
 })
 
+test('abort preserves running count and concurrency', function (t) {
+  t.plan(6)
+
+  var started = []
+  var finish = []
+  var queue = buildQueue(worker, 1)
+
+  queue.push(1)
+  queue.push(2)
+  queue.abort()
+
+  t.equal(queue.running(), 1, 'running task is preserved')
+
+  queue.push(3)
+  t.deepEqual(started, [1], 'new task does not exceed concurrency')
+
+  finish.shift()()
+
+  t.deepEqual(started, [1, 3], 'new task starts after the running task')
+  t.equal(queue.running(), 1, 'replacement task is counted')
+
+  finish.shift()()
+
+  t.equal(queue.running(), 0, 'running returns to zero')
+  t.ok(queue.idle(), 'queue is idle')
+
+  function worker (task, cb) {
+    started.push(task)
+    finish.push(function () {
+      cb(null, task)
+    })
+  }
+})
+
+test('abort callbacks can safely add tasks', function (t) {
+  t.plan(8)
+
+  var expected = ['active', 'new-1-a', 'new-1-b', 'new-2-a', 'new-2-b']
+  var started = []
+  var finish = []
+  var queue = buildQueue(worker, 1)
+
+  queue.push('active')
+  queue.push('aborted-1', requeue('1'))
+  queue.push('aborted-2', requeue('2'))
+  queue.abort()
+
+  t.equal(queue.running(), 1, 'running task is preserved')
+  t.equal(queue.length(), 4, 'tasks added by callbacks remain queued')
+  t.deepEqual(started, ['active'], 'added tasks wait for the running task')
+
+  for (var i = 0; i < expected.length; i++) {
+    finish.shift()()
+  }
+
+  t.deepEqual(started, expected, 'added tasks are processed once in order')
+  t.equal(queue.running(), 0, 'running returns to zero')
+  t.ok(queue.idle(), 'queue is idle')
+
+  function requeue (suffix) {
+    return function (err) {
+      t.equal(err.message, 'abort', 'callback receives abort error')
+      queue.push('new-' + suffix + '-a')
+      queue.push('new-' + suffix + '-b')
+    }
+  }
+
+  function worker (task, cb) {
+    started.push(task)
+    finish.push(function () {
+      cb(null, task)
+    })
+  }
+})
+
 test('abort with error handler', function (t) {
   t.plan(7)
 


### PR DESCRIPTION
## Summary

- return aborted queued tasks directly to the object pool without changing the active worker count
- detach queued nodes before invoking callbacks so reentrant queue additions remain safe
- add callback and promise regressions for concurrency accounting and drain completion

## Tests

- `npm test`
- `npm run typescript`
