### PR TITLE
build: replace .npmignore with a files allowlist

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-scripts
-CLAUDE.md
-.github

--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "description": "Fast, in memory work queue",
   "main": "queue.js",
   "type": "commonjs",
+  "files": [
+    "queue.js",
+    "index.d.ts",
+    "SECURITY.md"
+  ],
   "scripts": {
     "lint": "eslint .",
     "unit": "nyc --lines 100 --branches 100 --functions 100 --check-coverage --reporter=text tape test/test.js test/promise.js",


### PR DESCRIPTION
## Problem

`.npmignore` is a denylist, so it is fail-open: any new file in the repo root ships unless someone remembers to add it. That is how `.github/dependabot.yml` and `.github/workflows/ci.yml` ended up inside the published tarball up through **v1.19.1**:

```
$ npm pack fastq@1.19.1 && tar -tzf fastq-1.19.1.tgz | grep github
package/.github/workflows/ci.yml
package/.github/dependabot.yml
```

That was fixed in 1.20.0 by adding `.github` to `.npmignore`, but the underlying failure mode is still there for the next file someone adds.

## Change

Replace `.npmignore` with a `files` allowlist in `package.json`, which is fail-closed:

```json
"files": [
  "queue.js",
  "index.d.ts",
  "SECURITY.md"
],
```

`README.md`, `LICENSE` and `package.json` are always included by npm, so they do not need listing.

## Effect on the tarball

| | before | after |
|---|---|---|
| files | 14 | 6 |
| unpacked | 50.6 kB | ~21 kB |

Also dropped from the package, none of which consumers need at runtime: `test/`, `bench.js`, `eslint.config.js`, `example.js`, `example.mjs`.

`example.js` / `example.mjs` are the only judgement call here — they were published before, so this is technically breaking for anyone deep-importing `fastq/example.mjs`. Happy to add them back if you would rather keep them.

Verified with `npm pack --dry-run`. No runtime code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)